### PR TITLE
feat: copy exported note to clipboard

### DIFF
--- a/main.ts
+++ b/main.ts
@@ -54,8 +54,7 @@ export default class WhatsappExportNotePlugin extends Plugin {
 			""
 		)}-whatsapp-${date.toISOString().replaceAll(":", "_")}.md`;
 		await this.app.vault.create(fullPathForNewNote, converted);
-		new Notice(
-			"Note exported successfully, copy its content and send it to WhatsApp"
-		);
+		await navigator.clipboard.writeText(converted);
+		new Notice("Note exported and copied to clipboard!");
 	}
 }


### PR DESCRIPTION
## What

After exporting the note, copy the converted WhatsApp-formatted text to the clipboard automatically, so you can paste directly into WhatsApp without opening and copying the generated file.

**Change is two lines:**
- Add `await navigator.clipboard.writeText(converted)` after `vault.create()`
- Update the success notice string

## Why

Addresses #1 — the generated file requires a second manual step (open → select all → copy) before you can paste into WhatsApp. Copying to clipboard at export time eliminates that friction.

`navigator.clipboard.writeText()` works in Obsidian desktop (Electron) and mobile (Capacitor/Android/iOS).

## Scope

No new dependencies, no behaviour change for the file-creation path, no settings added.